### PR TITLE
Add support for python 3.8 to 3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [Version 1.1.0](https://github.com/dataiku/dss-plugin-amazon-comprehend-nlp/releases/tag/v1.1.0) - 2023-04
+
+- ✨ Added support for Python 3.8, 3.9, 3.10, 3.11

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -8,7 +8,7 @@
 		"PYTHON310",
 		"PYTHON311"
 	],
-	"corePackageSet": "AUTO",
+	"corePackagesSet": "AUTO",
 	"forceConda": false,
 	"installCorePackages": true,
 	"installJupyterSupport": false

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -2,8 +2,13 @@
 	"acceptedPythonInterpreters": [
 		"PYTHON35",
 		"PYTHON36",
-		"PYTHON37"
+		"PYTHON37",
+		"PYTHON38",
+		"PYTHON39",
+		"PYTHON310",
+		"PYTHON311"
 	],
+	"corePackageSet": "AUTO",
 	"forceConda": false,
 	"installCorePackages": true,
 	"installJupyterSupport": false

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "amazon-comprehend-nlp",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "meta": {
         "label": "Amazon Comprehend NLP",
         "category": "Natural Language Processing",


### PR DESCRIPTION
Tested the 4 recipes locally on the latest daily instance of DSS12 (`dip-release-12.0-daily-33`) with code env built using
- [x] python 3.5
- [x] python 3.6
- [x] python 3.7
- [x] python 3.8
- [x] python 3.9
- [x] python 3.10
- [x] python 3.11